### PR TITLE
Add the "_" param to the request, Denon seems to use it for some sort…

### DIFF
--- a/device-denon-avr.groovy
+++ b/device-denon-avr.groovy
@@ -199,10 +199,12 @@ def refresh() {
     def hosthex = convertIPtoHex(destIp)
     def porthex = convertPortToHex(destPort)
     device.deviceNetworkId = "$hosthex:$porthex" 
+    // Get a date string in millis
+    def ourDate = new Date().getTime()
 
     def hubAction = new physicalgraph.device.HubAction(
-   	 		'method': 'GET',
-    		'path': "/goform/formMainZone_MainZoneXml.xml",
+            'method': 'GET',
+            'path': "/goform/formMainZone_MainZoneXml.xml?_=$ourDate",
             'headers': [ HOST: "$destIp:$destPort" ] 
 		) 
         


### PR DESCRIPTION
… of cache busting on my X1200w.  Without it I rarely see the list of inputs returned to the device handler.
